### PR TITLE
Speed up second-step MFA code validation by optimizing backup code check order

### DIFF
--- a/trench/command/authenticate_second_factor.py
+++ b/trench/command/authenticate_second_factor.py
@@ -27,11 +27,11 @@ class AuthenticateSecondFactorCommand:
 
     def is_authenticated(self, user_id: int, code: str) -> None:
         for auth_method in self._mfa_model.objects.list_active(user_id=user_id):
+            if get_mfa_handler(mfa_method=auth_method).validate_code(code=code):
+                return
             validated_backup_code = validate_backup_code_command(
                 value=code, backup_codes=auth_method.backup_codes
             )
-            if get_mfa_handler(mfa_method=auth_method).validate_code(code=code):
-                return
             if validated_backup_code:
                 remove_backup_code_command(
                     user_id=auth_method.user_id, method_name=auth_method.name, code=code


### PR DESCRIPTION
This PR refactors the second step of MFA code validation to improve performance. Previously, the logic always started by comparing the MFA code to a backup code, which is a slow operation due to the use of Django's check_password (averaging 170ms per call). The new logic optimizes this by changing the order of validation, reducing unnecessary calls to check_password and speeding up the process, especially under server load.\n\n- Refactored MFA code validation logic to avoid always checking backup codes first\n- Reduced reliance on expensive check_password calls\n- Improved overall speed of second-step MFA validation\n\nNo changes to the public API or configuration. All tests pass.\n\nCloses #speedup-mfa-validation.